### PR TITLE
perms fchmod fsync

### DIFF
--- a/sambacc/permissions.py
+++ b/sambacc/permissions.py
@@ -145,7 +145,14 @@ class InitPosixPermsHandler:
         # yeah, this is really simple compared to all the state management
         # stuff.
         path = self._full_path()
-        os.chmod(path, self._mode, follow_symlinks=False)
+        dfd = os.open(path, os.O_DIRECTORY)
+        try:
+            os.fchmod(dfd, self._mode)
+            os.fsync(dfd)
+        except OSError:
+            os.sync()
+        finally:
+            os.close(dfd)
 
     def _timestamp(self) -> str:
         return datetime.datetime.now().strftime("%s")


### PR DESCRIPTION
Manipulate directory via file-descriptor (instead of path) to ensure
that 'fchmod(2)' system call is flushed all the way into stable
storage with additional 'fsync(2)'.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>